### PR TITLE
added pre-commit hook for check-manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,8 @@ repos:
           - id: mypy
             additional_dependencies:
                 - types-setuptools
+    - repo: https://github.com/mgedmin/check-manifest
+      rev: "0.49"
+      hooks:
+          - id: check-manifest
+            additional_dependencies: [setuptools-scm]


### PR DESCRIPTION
Because this always trips me up, and I always forget to check the manifest before pushing.
Happy to also add this to the cookiecutter.